### PR TITLE
document correct usage for library authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This library defines a macro, which allows developers to provide easy-to-parse information to security researchers that wish to contact the authors of a Solana smart contract.
 It is inspired by https://securitytxt.org/.
 
-See the an example in the Solana Explorer: https://explorer.solana.com/address/HPxKXnBN4vJ8RjpdqDCU7gvNQHeeyGnSviYTJ4fBrDt4/security?cluster=devnet
+See this example in the Solana Explorer: https://explorer.solana.com/address/HPxKXnBN4vJ8RjpdqDCU7gvNQHeeyGnSviYTJ4fBrDt4/security?cluster=devnet
 
 
 ## Motivation
@@ -45,9 +45,25 @@ The `security_txt` macro is intentionally kept brief. As such, it doesn't do any
 query-security-txt target/bpfel-unknown-unknown/release/example_contract.so
 ```
 
+#### Notice for library authors
+If you expect your contract to be used as a dependency in other contracts, you **must** exclude the macro when your
+contract is being built as a library, i.e., when the `no-entrypoint` feature is being used.
+Consult the example snippet below or the full example in the `example-contract` directory for details.
+
+#### Troubleshooting: linker error `multiple definition of security_txt`
+If you encounter this error during building, then that means that the `security_txt` macro has been used multiple times.
+This is probably caused by one of your dependencies also using the macro, which causes a name conflict during building.
+
+In that case, please tell the authors of that dependency to read the above notice for library authors and add the
+following to the macro to exclude it from `no-entrypoint` builds.
+```rust
+#[cfg(not(feature = "no-entrypoint"))]
+```
+
 ### Example
 
 ```rust
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     // Required fields
     name: "Example",

--- a/example-contract/src/lib.rs
+++ b/example-contract/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use solana_security_txt::security_txt;
 
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     // Required fields
     name: "Example",

--- a/security-txt/src/lib.rs
+++ b/security-txt/src/lib.rs
@@ -44,6 +44,7 @@
 //! ### Example
 //!
 //! ```rust
+//! #[cfg(not(feature = "no-entrypoint"))]
 //! security_txt! {
 //!     // Required fields
 //!     name: "Example",


### PR DESCRIPTION
This addresses #11:
> When using another smart-contract as dependency it also generates it's security.txt.
The compiler is helpful here and prevents two conflicting security.txt being present.
> 
> Dependencies have to omit emitting the security.txt. Solana contracts already use the no-entrypoint feature to avoid including entrypoints of dependent smart-contracts, this can easily be adapted here.
> 
> We have brainstormed a bit, but there doesn't seem to be a fool-proof solution for solving this automatically. So there isn't much we can do about that from the perspective from this crate. The decision to include or not include the macro always has to happen from the caller, and we cannot introspect if the parent is compiled with no-entrypoint.
> 
> This aspect is currently lacking from the documentation, working on a pull-request to fix this, and make it very clear that if you expect to be included as dependency and have an exposed no_entrypoint feature, you have to put the security.txt under that as well:
> 
> ```rust
> #[cfg(not(feature = "no-entrypoint"))]
> security_txt! {
> ...
> }
> ```
> 
> Unfortunately, this issue means contracts that currently do not do this cannot be used as a dependency until they are updated.