### PR TITLE
Adding doc comments to macro lines

### DIFF
--- a/security-txt/src/lib.rs
+++ b/security-txt/src/lib.rs
@@ -5,15 +5,19 @@ mod parser;
 #[cfg(feature = "parser")]
 pub use crate::parser::*;
 
+/// Constant for the beginning of the security.txt file.
 pub const SECURITY_TXT_BEGIN: &str = "=======BEGIN SECURITY.TXT V1=======\0";
+/// Constant for the end of the security.txt file.
 pub const SECURITY_TXT_END: &str = "=======END SECURITY.TXT V1=======\0";
 
 #[macro_export]
+/// Create a static string containing the security.txt file.
 macro_rules! security_txt {
     ($($name:ident: $value:expr),*) => {
         #[cfg_attr(target_arch = "bpf", link_section = ".security.txt")]
         #[allow(dead_code)]
         #[no_mangle]
+        /// Static string containing the security.txt file.
         pub static security_txt: &str = concat! {
             "=======BEGIN SECURITY.TXT V1=======\0",
             $(stringify!($name), "\0", $value, "\0",)*


### PR DESCRIPTION
Required for programs using #![deny(missing_docs)] being build.

Using the macro `security_txt!` in current state causes build errors

```
cargo build-sbf --manifest-path=./Cargo.toml --sbf-out-dir=target/

error: missing documentation for a static
  --> program/src/lib.rs:16:1
   |
16 | / security_txt! {
17 | |     name: "...",
18 | |     project_url: "...",
19 | |     contacts: "...",
...  |
23 | |     auditors: "..."
24 | | }
   | |_^
   |
note: the lint level is defined here
  --> program/src/lib.rs:2:9
   |
2  | #![deny(missing_docs)]
   |         ^^^^^^^^^^^^
   = note: this error originates in the macro `security_txt` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `program` due to previous error
```