### PR TITLE
Bump and unlock dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,8 +2212,8 @@ name = "solana-security-txt"
 version = "1.1.2"
 dependencies = [
  "hashbrown 0.15.2",
+ "memchr",
  "thiserror 2.0.18",
- "twoway",
 ]
 
 [[package]]
@@ -2798,26 +2798,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "twoway"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,7 +2137,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2163,7 +2163,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-version",
  "spl-generic-token",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2183,7 +2183,7 @@ dependencies = [
  "hash32",
  "log",
  "rustc-demangle",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2212,7 +2212,7 @@ name = "solana-security-txt"
 version = "1.1.2"
 dependencies = [
  "hashbrown 0.15.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "twoway",
 ]
 
@@ -2428,7 +2428,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2560,11 +2560,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2580,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,23 +23,12 @@ version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be80c9787c7f30819e2999987cc6208c1ec6f775d7ed2b70f61a00a6e8acc0c8"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "solana-epoch-schedule",
  "solana-hash 3.1.0",
  "solana-pubkey 3.0.0",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -742,9 +731,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2202,7 +2188,6 @@ dependencies = [
 name = "solana-security-txt"
 version = "1.1.2"
 dependencies = [
- "hashbrown 0.11.2",
  "memchr",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,23 @@ version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be80c9787c7f30819e2999987cc6208c1ec6f775d7ed2b70f61a00a6e8acc0c8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "solana-epoch-schedule",
  "solana-hash 3.1.0",
  "solana-pubkey 3.0.0",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -58,12 +69,6 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
@@ -587,12 +592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,16 +742,8 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2211,7 +2202,7 @@ dependencies = [
 name = "solana-security-txt"
 version = "1.1.2"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.11.2",
  "memchr",
  "thiserror 2.0.18",
 ]

--- a/security-txt/Cargo.toml
+++ b/security-txt/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT OR Apache-2.0"
 
 [features]
 # when no features are enabled, this crate has no dependencies. The parser requires two, but won't be used on-chain.
-parser = ["thiserror", "twoway"]
+parser = ["thiserror", "memchr"]
 
 [dependencies]
 hashbrown = "=0.15.2"
 thiserror = { version = "2", optional = true }
-twoway = { version = "=0.2.2", optional = true }
+memchr = { version = "2", optional = true }

--- a/security-txt/Cargo.toml
+++ b/security-txt/Cargo.toml
@@ -12,5 +12,6 @@ license = "MIT OR Apache-2.0"
 parser = ["thiserror", "memchr"]
 
 [dependencies]
-thiserror = { version = "2", optional = true }
-memchr = { version = "2", optional = true }
+# no default features to allow no_std
+thiserror = { version = "2", optional = true, default-features = false }
+memchr = { version = "2", optional = true, default-features = false }

--- a/security-txt/Cargo.toml
+++ b/security-txt/Cargo.toml
@@ -12,6 +12,6 @@ license = "MIT OR Apache-2.0"
 parser = ["thiserror", "memchr"]
 
 [dependencies]
-hashbrown = "=0.15.2"
+hashbrown = "0"
 thiserror = { version = "2", optional = true }
 memchr = { version = "2", optional = true }

--- a/security-txt/Cargo.toml
+++ b/security-txt/Cargo.toml
@@ -12,6 +12,5 @@ license = "MIT OR Apache-2.0"
 parser = ["thiserror", "memchr"]
 
 [dependencies]
-hashbrown = "0"
 thiserror = { version = "2", optional = true }
 memchr = { version = "2", optional = true }

--- a/security-txt/Cargo.toml
+++ b/security-txt/Cargo.toml
@@ -13,5 +13,5 @@ parser = ["thiserror", "twoway"]
 
 [dependencies]
 hashbrown = "=0.15.2"
-thiserror = { version = "=2.0.16", optional = true }
+thiserror = { version = "2", optional = true }
 twoway = { version = "=0.2.2", optional = true }

--- a/security-txt/src/parser.rs
+++ b/security-txt/src/parser.rs
@@ -1,5 +1,6 @@
 use crate::{SECURITY_TXT_BEGIN, SECURITY_TXT_END};
 use alloc::{
+    collections::BTreeMap,
     string::{String, ToString},
     vec::Vec,
 };
@@ -7,9 +8,8 @@ use core::{
     fmt::{self, Display},
     str::from_utf8,
 };
-use alloc::collections::BTreeMap;
-use thiserror::Error;
 use memchr::memmem::find as find_bytes;
+use thiserror::Error;
 
 pub enum Contact {
     Email(String),

--- a/security-txt/src/parser.rs
+++ b/security-txt/src/parser.rs
@@ -7,7 +7,7 @@ use core::{
     fmt::{self, Display},
     str::from_utf8,
 };
-use hashbrown::HashMap;
+use alloc::collections::BTreeMap;
 use thiserror::Error;
 use memchr::memmem::find as find_bytes;
 
@@ -162,7 +162,7 @@ pub fn parse(mut data: &[u8]) -> Result<SecurityTxt, SecurityTxtError> {
 
     data = &data[SECURITY_TXT_BEGIN.len()..end];
 
-    let mut attributes = HashMap::<String, String>::default();
+    let mut attributes = BTreeMap::<String, String>::new();
     let mut field: Option<String> = None;
     for part in data.split(|&b| b == 0) {
         if let Some(ref f) = field {

--- a/security-txt/src/parser.rs
+++ b/security-txt/src/parser.rs
@@ -9,7 +9,7 @@ use core::{
 };
 use hashbrown::HashMap;
 use thiserror::Error;
-use twoway::find_bytes;
+use memchr::memmem::find as find_bytes;
 
 pub enum Contact {
     Email(String),


### PR DESCRIPTION
This pull request updates the `security-txt` crate to simplify dependencies. The main changes are the replacement of the `twoway` and `hashbrown` crates with `memchr` and Rust's standard `BTreeMap`, respectively, and the update of dependency versions for better compatibility.

**Dependency updates and simplification:**

* Replaced the `twoway` crate with the `memchr` crate for byte searching in the parser, updating both the feature list and the implementation (`Cargo.toml`, `parser.rs`). [[1]](diffhunk://#diff-30dee9b821ea4cd7cbc0e5fa3b2d010699eea85b6ccfffd5d882173c972b7a1cL12-R16) [[2]](diffhunk://#diff-4c1088d0ab6f1f2730ae8fe9a694fbdc87562c23ad1511c0b585cfef48d127fcL10-R12)
* Removed the `hashbrown` dependency and switched from `HashMap` to `BTreeMap` for attribute storage in the parser, reducing dependencies (`Cargo.toml`, `parser.rs`). [[1]](diffhunk://#diff-30dee9b821ea4cd7cbc0e5fa3b2d010699eea85b6ccfffd5d882173c972b7a1cL12-R16) [[2]](diffhunk://#diff-4c1088d0ab6f1f2730ae8fe9a694fbdc87562c23ad1511c0b585cfef48d127fcL10-R12) [[3]](diffhunk://#diff-4c1088d0ab6f1f2730ae8fe9a694fbdc87562c23ad1511c0b585cfef48d127fcL165-R165)
* Updated the version specification for the `thiserror` dependency to a more flexible version in `Cargo.toml`.