### PR TITLE
feat(token): add security.txt for responsible disclosure

### DIFF
--- a/Build & Deploy Commands
+++ b/Build & Deploy Commands
@@ -1,0 +1,17 @@
+# 1. Clone the token program repository
+git clone https://github.com/solana-program/token.git
+cd token/program
+
+# 2. Add the dependency and security_txt! macro (as shown above)
+
+# 3. Build the program
+cargo build-sbf
+
+# 4. Verify the security.txt is embedded
+query-security-txt target/sbpf-solana-solana/release/spl_token.so
+
+# 5. Deploy the upgrade (requires program upgrade authority)
+solana program deploy   --program-id TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA   target/sbpf-solana-solana/release/spl_token.so
+
+# 6. Verify on-chain
+query-security-txt TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -1,0 +1,17 @@
+#[cfg(not(feature = "no-entrypoint"))]
+use solana_security_txt::security_txt;
+
+#[cfg(not(feature = "no-entrypoint"))]
+security_txt! {
+    name: "SPL Token Program",
+    project_url: "https://solana.com",
+    contacts: "email:security@anza.xyz,link:https://github.com/solana-labs/solana/security/advisories/new",
+    policy: "https://github.com/solana-labs/solana/blob/master/SECURITY.md",
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-program/token",
+    source_revision: "4fadd55",
+    source_release: "3.4.0",
+    auditors: "Peer Review (2022-08-04)",
+    acknowledgements: "https://github.com/solana-labs/solana/security/advisories",
+    expiry: "2027-12-31"
+}

--- a/token/program/src/token/program/Cargo.toml
+++ b/token/program/src/token/program/Cargo.toml
@@ -1,2 +1,4 @@
 [dependencies]
 solana-security-txt = "1.1.3"
+cargo build-sbf
+query-security-txt target/sbpf-solana-solana/release/spl_token.so

--- a/token/program/src/token/program/Cargo.toml
+++ b/token/program/src/token/program/Cargo.toml
@@ -1,0 +1,2 @@
+[dependencies]
+solana-security-txt = "1.1.3"

--- a/token/program/src/token/program/Cargo.toml
+++ b/token/program/src/token/program/Cargo.toml
@@ -1,4 +1,2 @@
 [dependencies]
 solana-security-txt = "1.1.3"
-cargo build-sbf
-query-security-txt target/sbpf-solana-solana/release/spl_token.so

--- a/token_program_security_tx
+++ b/token_program_security_tx
@@ -1,0 +1,14 @@
+
+---
+
+## 6. VERIFICATION STEPS
+
+After deployment, verify the fix:
+
+### 6.1 Using `query-security-txt` CLI
+```bash
+# Install the tool if not already installed
+cargo install query-security-txt
+
+# Query the on-chain program
+query-security-txt TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA


### PR DESCRIPTION
## Summary
Adds `solana-security-txt` to the SPL Token Program so that security researchers can easily identify the correct contact for vulnerability disclosures.

## Motivation
The Solana Explorer currently displays `Program has no security.txt` in red for the Token Program (`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`). This makes it difficult for whitehat researchers to report security issues responsibly, potentially delaying critical bug fixes.

## Changes
- Added `solana-security-txt = "1.1.3"` to `token/program/Cargo.toml`
- Added `security_txt!` macro invocation in `token/program/src/lib.rs`
- Included all required fields: name, project_url, contacts, policy
- Included optional fields: source_code, source_revision, source_release, auditors, acknowledgements, expiry

## Security Contact
- Email: security@anza.xyz
- Advisory Portal: https://github.com/solana-labs/solana/security/advisories/new
- Policy: https://github.com/solana-labs/solana/blob/master/SECURITY.md

## Verification
```bash
query-security-txt target/sbpf-solana-solana/release/spl_token.so